### PR TITLE
Bump Glide to 4.3.0 to fix GIF rendering performance in ShotDetailFragment

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,7 +55,7 @@ ext.retrofitVersion = '2.3.0'
 ext.loggerVersion = '2.2.0'
 ext.daggerVersion = '2.11'
 ext.archVersion = '1.0.0-alpha8'
-ext.glideVersion = '4.0.0'
+ext.glideVersion = '4.3.0'
 dependencies {
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])


### PR DESCRIPTION
Turns out there was some performance issues regarding gif decoding to support more gif
formats. Please refer to this issue in the Glide project - https://github.com/bumptech/glide/issues/1744.
This seems to be fixed in 4.3.0. Gifs play fluidly now compared to 4.0.0.